### PR TITLE
Fix CleanupConfigFile

### DIFF
--- a/main.c
+++ b/main.c
@@ -418,12 +418,14 @@ static int ArgParse(int argc, char *argv_ori[])
     return 0;
 }
 
-static void CleanupConfig(void)
+static void CleanupConfigFile(void)
 {
-    if(ConfigInfo.Options.List == NULL)
-        return;
-    ConfigFree(&ConfigInfo);
     free(ConfigFile);
+}
+
+static void CleanupConfigInfo(void)
+{
+    ConfigFree(&ConfigInfo);
 }
 
 #ifdef WIN32
@@ -464,7 +466,7 @@ int main(int argc, char *argv[])
 
     ArgParse(argc, argv);
 
-    atexit(CleanupConfig);
+    atexit(CleanupConfigFile);
     if( ConfigFile == NULL )
     {
         ConfigFile = malloc(320);
@@ -499,6 +501,7 @@ int main(int argc, char *argv[])
         }
     }
 
+    atexit(CleanupConfigInfo);
     if( EnvironmentInit() != 0 )
     {
         return -498;

--- a/main.c
+++ b/main.c
@@ -466,7 +466,6 @@ int main(int argc, char *argv[])
 
     ArgParse(argc, argv);
 
-    atexit(CleanupConfigFile);
     if( ConfigFile == NULL )
     {
         ConfigFile = malloc(320);
@@ -474,6 +473,7 @@ int main(int argc, char *argv[])
         {
             return -264;
         }
+        atexit(CleanupConfigFile);
 
         GetDefaultConfigureFile(ConfigFile, 320);
     }


### PR DESCRIPTION
Free the ConfigFile pointer only when it points to a block of
allocated memory. Do not free it when it points to argv.