### PR TITLE
TCPGroup: compatible with old-style config files

### DIFF
--- a/mmgr.c
+++ b/mmgr.c
@@ -255,7 +255,15 @@ static int Tcp_Init(ModuleMap *ModuleMap, StringListIterator *i)
     Services = i->Next(i);
     Domains = i->Next(i);
     Parallel = i->Next(i);
-    Proxies = i->Next(i);
+    if ( strcmp(Parallel, "on") != 0 && strcmp(Parallel, "off") != 0 )
+    {
+        Proxies = Parallel;
+        Parallel = "off";
+    }
+    else
+    {
+        Proxies = i->Next(i);
+    }
 
     if( Domains == NULL )
     {


### PR DESCRIPTION
Due to the usage with old programs (e.g., luci-app-dnsforwarder in OpenWrt), dnsforwarder needs to be compatible with old-style config files.

old-style format:
TCPGroup <IP1[:PORT],IP2[:PORT],...> <DOMAIN1,DOMAIN2,...> <no|PROXY1[:PORT],PROXY2[:PORT],...>